### PR TITLE
update header of response message for scene control

### DIFF
--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -35,4 +35,30 @@ describe('responseEvent', () => {
 
     done()
   })
+  it('should generate response event for scene control activate', done => {
+    const req = require('./sample_messages/SceneController/SceneController.Activate.request.json')
+    const resEvent = utils.createResponseEvent(req)
+
+    expect(resEvent.header).to.contains({
+      namespace: 'Alexa.SceneController',
+      name: 'ActivationStarted',
+      payloadVersion: '3'
+    })
+    expect(resEvent.header).to.has.property('messageId')
+
+    done()
+  })
+  it('should generate response event for scene control deactivate', done => {
+    const req = require('./sample_messages/SceneController/SceneController.Deactivate.request.json')
+    const resEvent = utils.createResponseEvent(req)
+
+    expect(resEvent.header).to.contains({
+      namespace: 'Alexa.SceneController',
+      name: 'DeactivationStarted',
+      payloadVersion: '3'
+    })
+    expect(resEvent.header).to.has.property('messageId')
+
+    done()
+  })
 })

--- a/utils.js
+++ b/utils.js
@@ -14,6 +14,7 @@ function createMessageId () {
   const uuidv4 = require('uuid/v4')
   return uuidv4()
 }
+
 /**
  *
  *
@@ -32,6 +33,14 @@ function createResponseEvent (req) {
   } else if (req.directive.header.namespace === 'Alexa.CameraStreamController' && req.directive.header.name === 'InitializeCameraStreams') {
     event.header.namespace = req.directive.header.namespace
     event.header.name = 'Response'
+  } else if (req.directive.header.namespace === 'Alexa.SceneController') {
+    event.header.namespace = req.directive.header.namespace
+    if (req.directive.header.name === 'Activate') {
+      event.header.name = 'ActivationStarted'
+    }
+    if (req.directive.header.name === 'Deactivate') {
+      event.header.name = 'DeactivationStarted'
+    }
   } else {
     event.header.namespace = 'Alexa'
     event.header.name = 'Response'


### PR DESCRIPTION
Dear Mr.Dinh,
I'm updated response message for scene controll - activate/deactivate because header of message have contain name one of 'ActivationStarted' or 'DeactivationStarted', for more detail at [sample_messages - SceneController](https://github.com/alexa/alexa-smarthome/tree/master/sample_messages/SceneController)
Please check it,
Thanks