### PR TITLE
fix the error response example code in the README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,16 @@ If you don't provide equivalent function, the response will be `INVALID_DIRECTIV
 
 `cb` is the response function.
 
-If you want to return error, generate an new error object, with code of the intented error.
+If you want to return error, generate an new error object, with payload of the intented error.
 Example:
 
 ```{js}
 // if the device is un reachable
 let err = new Error()
-err.code = alehos.code.ERR_ENDPOINT_UNREACHABLE
+err.payload = {
+  type: alehos.code.ERR_ENDPOINT_UNREACHABLE,
+  message: 'device is un reachable'
+}
 return cb(err)
 ```
 


### PR DESCRIPTION
Hello, Mr.Dinh.

Thank you for useful package.

I found an old style error response example code in README.md.

Would you read two example codes as follow?

https://github.com/nqd/alehos3/blob/c50d0c762e7b0d90b16df18095bc4643ecfc132d/index.js#L159-L165

[Old version style]
```
let err = new Error()
err.code = alehos.code.ERR_ENDPOINT_UNREACHABLE
return cb(err)
```

[Current version style]
```
let err = new Error()
err.payload = {
  type: alehos.code.ERR_ENDPOINT_UNREACHABLE,
  message: 'device is un reachable'
}
return cb(err)
```

Regards,
masachaco